### PR TITLE
finally figured out the secret handshake to get custom css in rtd theme

### DIFF
--- a/openaerostruct/doc/_static/style.css
+++ b/openaerostruct/doc/_static/style.css
@@ -26,8 +26,86 @@ code {
 }
 
 div.output_area pre {
+    font-size: 10px;
     background-color: #ddd;
     border-radius: 2px;
     margin-top: 0px;
     margin-bottom: 0px;
+}
+
+div.highlight-python highlight{
+    font-size: 12px;
+}
+
+/* For In/Out blocks for embedded tests */
+div.input_area {
+    border-radius: 1px;
+    font-size: 12px;
+}
+
+div.input_area pre {
+    background-color: white;
+    border-radius: 2px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    font-size: 12px;
+}
+
+div.output_area pre {
+    background-color: #ddd;
+    border-radius: 2px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    font-size: 12px;
+}
+
+div.rosetta_left {
+    background-color: rgba(255, 238, 238, 1.0);
+    border-radius: 2px;
+    display: table-cell;
+    width: 50%;
+    border-top: 2px solid #c9a;
+    border-bottom: 2px solid #c9a;
+    border-left: 1px solid #c9a;
+    border-right: 2px solid #c9a;
+  }
+
+div.rosetta_right {
+    background-color: rgba(238, 255, 238, 1.0);
+    border-radius: 2px;
+    display: table-cell;
+    width: 50%;
+    border-top: 2px solid #ac9;
+    border-bottom: 2px solid #ac9;
+    border-left: 1px solid #ac9;
+    border-right: 2px solid #ac9;
+}
+
+div.rosetta_left pre {
+    background-color: rgba(255, 238, 238, 1.0);
+    border: none;
+}
+
+div.rosetta_right pre {
+    background-color: rgba(238, 255, 238, 1.0);
+    border: none;
+}
+
+div.rosetta_outer {
+    display: table;
+    width: 100%
+}
+
+div.highlight-python {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+/* Fix the Parameter block width problem */
+table.field-list th {
+    width: 80px;
+  }
+
+.highlight-python {
+    font-size: 12px;
 }

--- a/openaerostruct/doc/conf.py
+++ b/openaerostruct/doc/conf.py
@@ -5,12 +5,14 @@ import sys
 import os
 
 import openmdao
-
 openmdao_path = os.path.split(os.path.abspath(openmdao.__file__))[0]
+sys.path.insert(0, os.path.join(openmdao_path, 'docs', '_exts'))
+
+#import openaerostruct
+#openaero_path = os.path.split(os.path.abspath(openaerostruct.__file__))[0]
 
 sys.path.insert(0, os.path.abspath('..'))
 sys.path.insert(0, os.path.abspath('.'))
-sys.path.insert(0, os.path.join(openmdao_path, 'docs', '_exts'))
 
 # -- General configuration ------------------------------------------------
 
@@ -34,8 +36,6 @@ extensions = ['sphinx.ext.autodoc',
               #'embed_compare',
               #'embed_shell_cmd',
               #'embed_bibtex']
-# start off running the monkeypatch to keep options/parameters
-# usable in docstring for autodoc.
 
 
 # -- General configuration ------------------------------------------------
@@ -46,7 +46,6 @@ needs_sphinx = '1.6'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-
 
 numpydoc_show_class_members = False
 
@@ -102,15 +101,12 @@ todo_include_todos = False
 import sphinx_rtd_theme
 
 html_theme = "sphinx_rtd_theme"
-
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-html_theme = '_theme'
-
-# Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = ['.']
+html_static_path = ['_static']
+html_context = {
+    'css_files': ['_static/style.css',],
+}
 
 # # The name of an image file (relative to this directory) to place at the top
 # # of the sidebar.


### PR DESCRIPTION
apparently the rtd theme has a bug in it that prevents the usual custom css stuff from being easily imported.  Here, we solve that, and then add in the css from the openmdao embed stylesheet.